### PR TITLE
Devops challenge effort.

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Acceleration suite
+name: acceleration
+version: 0.1.0

--- a/acceleration-calc/package.json
+++ b/acceleration-calc/package.json
@@ -7,7 +7,7 @@
   "author": "JOIN Team",
   "license": "UNLICENSED",
   "scripts": {
-    "dev": "env-cmd .env ts-node ./server",
+    "dev": "env-cmd --no-override .env ts-node ./server",
     "start": "node dist",
     "build": "tsc",
     "build:clean": "rm -rf dist"

--- a/charts/acceleration-a/.helmignore
+++ b/charts/acceleration-a/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/acceleration-a/Chart.yaml
+++ b/charts/acceleration-a/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Acceleration-a
+name: acceleration-a
+version: 0.1.0

--- a/charts/acceleration-a/templates/NOTES.txt
+++ b/charts/acceleration-a/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "acceleration-a.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "acceleration-a.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "acceleration-a.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "acceleration-a.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/acceleration-a/templates/_helpers.tpl
+++ b/charts/acceleration-a/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "acceleration-a.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "acceleration-a.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "acceleration-a.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/acceleration-a/templates/deployment.yaml
+++ b/charts/acceleration-a/templates/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "acceleration-a.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "acceleration-a.name" . }}
+    helm.sh/chart: {{ include "acceleration-a.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas:  {{ .Values.global.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "acceleration-a.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "acceleration-a.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            [ '{{ .Values.global.yarncmd }}' ]
+          env:
+            {{- toYaml .Values.environment | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 1
+            failureThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 1
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/acceleration-a/templates/ingress.yaml
+++ b/charts/acceleration-a/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "acceleration-a.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "acceleration-a.name" . }}
+    helm.sh/chart: {{ include "acceleration-a.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/acceleration-a/templates/service.yaml
+++ b/charts/acceleration-a/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "acceleration-a.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "acceleration-a.name" . }}
+    helm.sh/chart: {{ include "acceleration-a.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "acceleration-a.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/acceleration-a/templates/tests/test-connection.yaml
+++ b/charts/acceleration-a/templates/tests/test-connection.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "acceleration-a.fullname" . }}-test-connection"
+  labels:
+    app.kubernetes.io/name: {{ include "acceleration-a.name" . }}
+    helm.sh/chart: {{ include "acceleration-a.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "acceleration-a.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/acceleration-a/values.yaml
+++ b/charts/acceleration-a/values.yaml
@@ -1,0 +1,51 @@
+# Default values for acceleration-a.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: "acceleration-a"
+  tag: "1.0.0-alpine"
+  pullPolicy: "Never"
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: "ClusterIP"
+  port: "3002"
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  # hosts:
+  #   - host: minikube.test
+  #     paths: ['/a']
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+environment:
+  - name: WEB_PORT
+    value: "3002"
+    
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/acceleration-calc/.helmignore
+++ b/charts/acceleration-calc/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/acceleration-calc/Chart.yaml
+++ b/charts/acceleration-calc/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Acceleration-calc
+name: acceleration-calc
+version: 0.1.0

--- a/charts/acceleration-calc/templates/NOTES.txt
+++ b/charts/acceleration-calc/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "acceleration-calc.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "acceleration-calc.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "acceleration-calc.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "acceleration-calc.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/acceleration-calc/templates/_helpers.tpl
+++ b/charts/acceleration-calc/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "acceleration-calc.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "acceleration-calc.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "acceleration-calc.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/acceleration-calc/templates/deployment.yaml
+++ b/charts/acceleration-calc/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "acceleration-calc.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "acceleration-calc.name" . }}
+    helm.sh/chart: {{ include "acceleration-calc.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas:  {{ .Values.global.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "acceleration-calc.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "acceleration-calc.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            [ '{{ .Values.global.yarncmd }}' ]
+          env:
+            {{- toYaml .Values.environment | nindent 12 }}
+            - name: A_URL
+              value: {{ tpl .Values.A_URL . | quote }}
+            - name: DV_URL
+              value: {{ tpl .Values.DV_URL . | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 1
+            failureThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 1
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/acceleration-calc/templates/ingress.yaml
+++ b/charts/acceleration-calc/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "acceleration-calc.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "acceleration-calc.name" . }}
+    helm.sh/chart: {{ include "acceleration-calc.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/acceleration-calc/templates/service.yaml
+++ b/charts/acceleration-calc/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "acceleration-calc.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "acceleration-calc.name" . }}
+    helm.sh/chart: {{ include "acceleration-calc.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "acceleration-calc.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/acceleration-calc/templates/tests/test-connection.yaml
+++ b/charts/acceleration-calc/templates/tests/test-connection.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "acceleration-calc.fullname" . }}-test-connection"
+  labels:
+    app.kubernetes.io/name: {{ include "acceleration-calc.name" . }}
+    helm.sh/chart: {{ include "acceleration-calc.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "acceleration-calc.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/acceleration-calc/values.yaml
+++ b/charts/acceleration-calc/values.yaml
@@ -1,0 +1,61 @@
+# Default values for acceleration-calc.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: "acceleration-calc"
+  tag: "1.0.0-alpine"
+  pullPolicy: "Never"
+
+# URLs are parsed and injected into env vars in deployment.yaml
+A_URL: "http://{{ .Release.Name }}-acceleration-a:3002/a"
+DV_URL: "http://{{ .Release.Name }}-acceleration-dv:3001/dv"
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: "NodePort"
+  port: "3000"
+
+ingress:
+  enabled: true
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: "minikube.test"
+      paths: ['/calc']
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+environment:
+  - name: WEB_PORT
+    value: "3000"
+  # - name: A_URL
+  #   value: http://acceleration-a:3002/a
+  # - name: DV_URL
+  #   value: http://acceleration-dv:3001/dv
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after "resources:".
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/acceleration-dv/.helmignore
+++ b/charts/acceleration-dv/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/acceleration-dv/Chart.yaml
+++ b/charts/acceleration-dv/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Acceleration-dv
+name: acceleration-dv
+version: 0.1.0

--- a/charts/acceleration-dv/templates/NOTES.txt
+++ b/charts/acceleration-dv/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "acceleration-dv.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "acceleration-dv.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "acceleration-dv.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "acceleration-dv.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/acceleration-dv/templates/_helpers.tpl
+++ b/charts/acceleration-dv/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "acceleration-dv.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "acceleration-dv.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "acceleration-dv.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/acceleration-dv/templates/deployment.yaml
+++ b/charts/acceleration-dv/templates/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "acceleration-dv.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "acceleration-dv.name" . }}
+    helm.sh/chart: {{ include "acceleration-dv.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.global.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "acceleration-dv.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "acceleration-dv.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            [ '{{ .Values.global.yarncmd }}' ]
+          env:
+            {{- toYaml .Values.environment | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 1
+            failureThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 1
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/acceleration-dv/templates/ingress.yaml
+++ b/charts/acceleration-dv/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "acceleration-dv.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "acceleration-dv.name" . }}
+    helm.sh/chart: {{ include "acceleration-dv.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/acceleration-dv/templates/service.yaml
+++ b/charts/acceleration-dv/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "acceleration-dv.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "acceleration-dv.name" . }}
+    helm.sh/chart: {{ include "acceleration-dv.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "acceleration-dv.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/acceleration-dv/templates/tests/test-connection.yaml
+++ b/charts/acceleration-dv/templates/tests/test-connection.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "acceleration-dv.fullname" . }}-test-connection"
+  labels:
+    app.kubernetes.io/name: {{ include "acceleration-dv.name" . }}
+    helm.sh/chart: {{ include "acceleration-dv.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "acceleration-dv.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/acceleration-dv/values.yaml
+++ b/charts/acceleration-dv/values.yaml
@@ -1,0 +1,51 @@
+# Default values for acceleration-dv.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: "acceleration-dv"
+  tag: "1.0.0-alpine"
+  pullPolicy: "Never"
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: "ClusterIP"
+  port: "3001"
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  # hosts:
+  #   - host: minikube.test
+  #     paths: ['/dv']
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+environment:
+  - name: WEB_PORT
+    value: "3001"
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+node_tag=8.16.0-alpine
+build_tag=1.0.0-alpine
+vm_driver=${vm_driver:-virtualbox}
+minikube_profile=udkyo
+namespace=udkyo
+release_name=jackal
+
+services=( a calc dv )
+
+get_platform_info() {
+  os=$(uname|tr '[:upper:]' '[:lower:]')
+  arch=$(uname -m)
+  case $arch in
+    armv5*) arch="armv5";;
+    armv6*) arch="armv6";;
+    armv7*) arch="arm";;
+    aarch64) arch="arm64";;
+    x86) arch="386";;
+    x86_64) arch="amd64";;
+    i686) arch="386";;
+    i386) arch="386";;
+  esac
+}
+
+sudo_sedi () {
+  if sed --version >/dev/null 2>&1; then
+    sudo sed -i -- "$@"
+  else
+    sudo sed -i "" "$@"
+  fi
+}
+
+bootstrap() {
+  command -v minikube &>/dev/null || (
+    printf "Minikube executable not found in path, downloading...\n"
+    curl -Lo minikube "https://storage.googleapis.com/minikube/releases/latest/minikube-$os-$arch" && \
+    chmod +x minikube && \
+    sudo mv minikube /usr/local/bin
+  )
+  if [ "$vm_driver" = "kvm2" ]; then
+    command -v docker-machine-driver-kvm2 &>/dev/null || (
+      printf "KVM2 driver not found in path, downloading...\n"
+      curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2 \
+      && sudo install docker-machine-driver-kvm2 /usr/local/bin/
+      rm -f docker-machine-driver-kvm2
+    )
+  fi
+  command -v helm &>/dev/null || (
+    printf "Helm executable not found in path, downloading...\n"
+    curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
+    chmod 700 get_helm.sh
+    ./get_helm.sh
+    rm -f ./get_helm.sh
+  )
+  printf "Starting minikube...\n"
+  minikube start -p "$minikube_profile" --memory 4096 --cpus 2 --vm-driver "$vm_driver"
+  printf "Enabling ingress addon...\n"
+  minikube -p "$minikube_profile" addons enable ingress
+  printf "Initialising helm...\n"
+  helm init
+}
+
+teardown() {
+  minikube status -p "$minikube_profile" &>/dev/null && (
+    printf "Deleting minikube VM...\n"
+    minikube delete -p "$minikube_profile"
+  )
+  printf "Purging binaries...\n"
+  sudo rm -f /usr/local/bin/{docker-machine-driver-kvm2,minikube,helm,tiller}
+}
+
+build_container_images() {
+    eval "$(minikube -p $minikube_profile docker-env)"
+    sed s/NODE_TAG/$node_tag/ template.Dockerfile > Dockerfile
+    for service in "${services[@]}"
+    do
+      (
+      printf "Building container image: acceleration-%s\n" "$service"
+      cp Dockerfile "acceleration-$service/"
+      cd "acceleration-$service" || exit
+      docker build . -t "acceleration-$service:$build_tag"
+      rm Dockerfile
+      )
+    done
+    rm Dockerfile
+}
+
+remove_container_images() {
+    for service in "${services[@]}"
+    do
+        printf "Removing container image: acceleration-%s\n" "$service"
+        docker rmi "acceleration-$service:$build_tag"
+    done
+}
+
+deploy_services() {
+  if ! command -v helm; then echo "Helm not found, run with bootstrap first"; exit 1; fi
+  if helm ls --all "$release_name" &>/dev/null; then helm del "$release_name" --purge; fi
+  echo "Deploying $release_name" 
+  helm install  --namespace "$namespace" "." --name "$release_name"
+}
+
+update_hosts_file() {
+  printf "Getting ingress IP (may take a minute)...\n"
+  while [[ -z "$ingress_ip" ]]
+  do
+    sleep 5
+    ingress_ip=$(minikube -p "$minikube_profile" ip)
+  done
+  printf "Updating hosts file...\n"
+  if grep minikube.test /etc/hosts &>/dev/null; then
+    sudo_sedi "s/^.*minikube.test$/$ingress_ip minikube.test/" /etc/hosts
+  else
+    printf "%s minikube.test" "$ingress_ip" | sudo tee -a /etc/hosts
+  fi
+}
+
+test_app() {
+  curl "http://minikube.test/calc?vf=200&vi=5&t=123"
+  printf "\n"
+}
+
+get_platform_info
+
+case "$1" in
+"bootstrap")
+  bootstrap
+  ;;
+"teardown")
+  teardown
+  ;;
+"build")
+  build_container_images
+  ;;
+"clean")
+  remove_container_images
+  ;;
+"deploy")
+  deploy_services
+  update_hosts_file
+  ;;
+"go")
+  bootstrap
+  build_container_images
+  deploy_services
+  update_hosts_file
+  ;;
+"test")
+  test_app
+  ;;
+*)
+  printf "Usage: run.sh [OPTION]\n\n"
+  printf "Options:\n"
+  printf "  bootstrap    Download binaries, create minikube cluster, install helm\n"
+  printf "  build        Build supporting container images\n"
+  printf "  deploy       Helm install\n"
+  printf "  go           Bootstrap, build containers, deploy services, update hosts file\n"
+  printf "  test         curl \"http://minikube.test/calc?vf=200&vi=5&t=123\"\n"
+  printf "  clean        Remove container images\n"
+  printf "  teardown     Remove minikube cluster\n"
+  ;;
+esac

--- a/template.Dockerfile
+++ b/template.Dockerfile
@@ -1,0 +1,8 @@
+FROM node:NODE_TAG
+COPY . /app
+WORKDIR /app
+RUN yarn install && \
+    yarn build
+USER node
+ENTRYPOINT ["yarn"]
+CMD ["dev"]

--- a/values.yaml
+++ b/values.yaml
@@ -1,0 +1,3 @@
+global:
+  replicas: 2
+  yarncmd: start

--- a/values.yaml
+++ b/values.yaml
@@ -1,3 +1,4 @@
 global:
   replicas: 2
   yarncmd: start
+


### PR DESCRIPTION
I created a helper script to make my life a little easier, it's not very polished but it can set up the environment if required, build containers etc. You can transition from a clean Linux/Mac build to running services with `./run.sh go`. To specify a different vm driver for minikube when using the helper script, pass it into the environment before the command, e.g. `vm_driver=kvm2 ./run.sh go`

It should be noted that `./run.sh go` includes a step to add a record for minikube.test to /etc/hosts. By default, the application will be reachable on http://minikube.test/calc once deployed.

If you're already set up to deploy to a cluster with helm, you can just fire off the command manually (assuming the images are present). The replica count and yarn subcommand are parameterised as globals in the parent chart, so can be specified at install time e.g:

helm install -n accel . --set global.replicas=3 --set global.yarncmd=dev

This was my first real foray into Helm. I tried to keep it straightforward but there were a couple of places I felt like I strayed away from that goal (notably the way the URLs are injected into the calc containers for instance) - any feedback you can offer on where I did things rightly or wrongly would be appreciated.

Thanks!